### PR TITLE
GitHubのスペルを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 翻訳リクエストを受け付けるリポジトリ
 
 ## 翻訳リクエストの出し方
-現在、Githubからのみ受け付けております。
+現在、GitHubからのみ受け付けております。
 
-### Githubから翻訳リクエストを出す場合
-https://github.com/postdcc/translation_request/issues/new から新しくissueを立ててください。Githubのissue templateが設定されているので、それに従い入力をおこなってください。issueが立ち次第、POSTD編集部で記事の詳細を確認します。
+### GitHubから翻訳リクエストを出す場合
+https://github.com/postdcc/translation_request/issues/new から新しくissueを立ててください。GitHubのissue templateが設定されているので、それに従い入力をおこなってください。issueが立ち次第、POSTD編集部で記事の詳細を確認します。
 
 ## 翻訳リクエストを出した後の流れ
 


### PR DESCRIPTION
GitHubの正しい名称はGithubではなくGitHubですので修正いたしました。